### PR TITLE
Add list_run_sessions, stop_run_session tools

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,11 +6,13 @@ This document provides detailed documentation for all 22 MCP tools available in 
 
 Tools are organized into categories based on functionality:
 
-### Run Configuration Tools (2)
+### Run Configuration Tools (4)
 
 | Tool | Description |
 |------|-------------|
 | `list_run_configurations` | List all available run configurations |
+| `list_run_sessions` | List all active run sessions |
+| `stop_run_session` | Stop a run session |
 | `execute_run_configuration` | Execute a run configuration in run or debug mode |
 
 ### Debug Session Tools (4)
@@ -75,6 +77,8 @@ Tools are organized into categories based on functionality:
 - [Common Parameters](#common-parameters)
 - [Run Configuration Tools](#run-configuration-tools)
   - [list_run_configurations](#list_run_configurations)
+  - [list_run_sessions](#list_run_sessions)
+  - [stop_run_session](#stop_run_session)
   - [execute_run_configuration](#execute_run_configuration)
 - [Debug Session Tools](#debug-session-tools)
   - [list_debug_sessions](#list_debug_sessions)
@@ -180,6 +184,65 @@ Lists all run configurations available in the project.
 
 ---
 
+### list_run_sessions
+
+Lists all active run sessions (run-only processes, not debug sessions).
+
+**Use when:**
+- Monitoring active run processes
+- Checking which run configurations are currently executing
+- Finding process IDs for running applications
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_path` | string | No | Project path |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "list_run_sessions",
+    "arguments": {}
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "sessions": [
+    {
+      "id": "run_session_12345",
+      "name": "Application",
+      "state": "running",
+      "processId": 12345,
+      "executorId": "Run",
+      "runConfigurationName": "Application"
+    },
+    {
+      "id": "run_session_67890",
+      "name": "Build Project",
+      "state": "running",
+      "processId": 67890,
+      "executorId": "Build",
+      "runConfigurationName": "Build Project"
+    }
+  ],
+  "totalCount": 2
+}
+```
+
+**Session State Values:**
+- `running` - Process is actively executing
+- `stopped` - Process has terminated
+
+---
+
 ### execute_run_configuration
 
 Executes a run configuration in either 'run' or 'debug' mode.
@@ -222,6 +285,50 @@ Executes a run configuration in either 'run' or 'debug' mode.
   "message": "Started 'UserServiceTest' in debug mode"
 }
 ```
+
+---
+
+### stop_run_session
+
+Stops/terminates a run session.
+
+**Use when:**
+- Ending a run session
+- Stopping a running application
+- Cleaning up after running tests
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | No | Session to stop (uses first available if omitted) |
+| `project_path` | string | No | Project path |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "stop_run_session",
+    "arguments": {
+      "session_id": "run_session_12345"
+    }
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "status": "stopped",
+  "sessionId": "run_session_12345",
+  "message": "Run session stopped"
+}
+```
+
+**Note:** If no `session_id` is provided, the tool will stop the first available run session.
 
 ---
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/ToolRegistry.kt
@@ -13,7 +13,9 @@ import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.execution.StepOut
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.execution.StepOverTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.navigation.GetSourceContextTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig.ListRunConfigurationsTool
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig.ListRunSessionsTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig.RunConfigurationTool
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig.StopRunSessionTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.session.GetDebugSessionStatusTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.session.ListDebugSessionsTool
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.session.StartDebugSessionTool
@@ -55,7 +57,9 @@ class ToolRegistry {
     fun registerBuiltInTools() {
         // Run Configuration Tools
         register(ListRunConfigurationsTool())
+        register(ListRunSessionsTool())
         register(RunConfigurationTool())
+        register(StopRunSessionTool())
 
         // Debug Session Tools
         register(ListDebugSessionsTool())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/models/RunConfigModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/models/RunConfigModels.kt
@@ -61,3 +61,19 @@ data class StopSessionResult(
     val status: String,
     val message: String
 )
+
+@Serializable
+data class RunSessionInfo(
+    val id: String,
+    val name: String,
+    val state: String,
+    val processId: Long? = null,
+    val executorId: String? = null,
+    val runConfigurationName: String? = null
+)
+
+@Serializable
+data class RunSessionListResult(
+    val sessions: List<RunSessionInfo>,
+    val totalCount: Int
+)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/runconfig/ListRunSessionsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/runconfig/ListRunSessionsTool.kt
@@ -1,0 +1,90 @@
+package com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig
+
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.server.models.ToolAnnotations
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.models.RunSessionInfo
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.models.RunSessionListResult
+import com.intellij.openapi.project.Project
+import com.intellij.execution.process.ProcessHandler
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * MCP tool for listing all active run sessions in the IDE.
+ * 
+ * This tool retrieves information about running processes including their IDs,
+ * names, and current states. It is useful for discovering available sessions
+ * when multiple run sessions are active.
+ * 
+ * @param project The IntelliJ project context
+ */
+class ListRunSessionsTool : AbstractMcpTool() {
+
+    /**
+     * Lists all active run sessions with their IDs, names, and states.
+     * Use to discover session IDs when multiple run sessions are running.
+     */
+    override val name = "list_run_sessions"
+
+    override val description = """
+        Lists all active run sessions with their IDs, names, and states.
+        Use to discover session IDs when multiple run sessions are running.
+    """.trimIndent()
+
+    override val annotations = ToolAnnotations.readOnly("List Run Sessions")
+
+    override val inputSchema: JsonObject = buildJsonObject {
+        put("type", "object")
+        putJsonObject("properties") {
+            val (propName, propSchema) = projectPathProperty()
+            put(propName, propSchema)
+        }
+        put("required", buildJsonArray { })
+        put("additionalProperties", false)
+    }
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val executionManager = com.intellij.execution.ExecutionManager.getInstance(project)
+        val runningProcesses: Array<ProcessHandler> = executionManager.getRunningProcesses()
+
+        val sessionInfos: List<RunSessionInfo> = runningProcesses.map { processHandler ->
+            val processId = getProcessId(processHandler)
+            RunSessionInfo(
+                id = processId?.toString() ?: processHandler.hashCode().toString(),
+                name = processHandler.toString(),
+                state = if (processHandler.isProcessTerminated) "stopped" else "running",
+                processId = processId,
+                executorId = null,
+                runConfigurationName = null
+            )
+        }
+
+        return createJsonResult(RunSessionListResult(
+            sessions = sessionInfos,
+            totalCount = sessionInfos.size
+        ))
+    }
+
+    /**
+     * Retrieves the process ID from a ProcessHandler using reflection.
+     * 
+     * @param processHandler The process handler to extract the ID from
+     * @return The process ID if available, null otherwise
+     */
+    private fun getProcessId(processHandler: ProcessHandler): Long? {
+        return try {
+            val process = processHandler.javaClass.getMethod("getProcess").invoke(processHandler)
+            if (process is Process) {
+                process.pid()
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/runconfig/StopRunSessionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/runconfig/StopRunSessionTool.kt
@@ -1,0 +1,124 @@
+package com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.runconfig
+
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.server.models.ToolAnnotations
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.tools.models.StopSessionResult
+import com.intellij.execution.ExecutionManager
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * MCP tool for stopping active run sessions in the IDE.
+ * 
+ * This tool terminates running processes by destroying their process handlers.
+ * It is a destructive operation that cannot be undone. If no session ID is
+ * provided, the first active run session will be stopped.
+ * 
+ * @param project The IntelliJ project context
+ */
+class StopRunSessionTool : AbstractMcpTool() {
+
+    /**
+     * Terminates a run session, stopping the running process.
+     * Use to end a run session. This is a destructive operation that cannot be undone.
+     */
+    override val name = "stop_run_session"
+
+    override val description = """
+        Terminates a run session, stopping the running process.
+        Use to end a run session. This is a destructive operation that cannot be undone.
+    """.trimIndent()
+
+    override val annotations = ToolAnnotations.mutable("Stop Run Session", destructive = true)
+
+    override val inputSchema: JsonObject = buildJsonObject {
+        put("type", "object")
+        putJsonObject("properties") {
+            val (propName, propSchema) = projectPathProperty()
+            put(propName, propSchema)
+            val (sessionName, sessionSchema) = sessionIdProperty()
+            put(sessionName, sessionSchema)
+        }
+        put("required", buildJsonArray { })
+        put("additionalProperties", false)
+    }
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val sessionId = arguments["session_id"]?.jsonPrimitive?.content
+
+        val processHandler = resolveRunSession(project, sessionId)
+            ?: return createErrorResult(
+                if (sessionId != null) "Run session not found: $sessionId"
+                else "No active run session"
+            )
+
+        val resolvedSessionId = processHandler.hashCode().toString()
+        val sessionName = processHandler.toString()
+
+        return try {
+            if (processHandler.isProcessTerminated) {
+                createJsonResult(StopSessionResult(
+                    sessionId = resolvedSessionId,
+                    status = "already_stopped",
+                    message = "Run session '$sessionName' was already stopped"
+                ))
+            } else {
+                processHandler.destroyProcess()
+                createJsonResult(StopSessionResult(
+                    sessionId = resolvedSessionId,
+                    status = "stopped",
+                    message = "Run session '$sessionName' stopped"
+                ))
+            }
+        } catch (e: Exception) {
+            createErrorResult("Failed to stop session: ${e.message}")
+        }
+    }
+
+    /**
+     * Resolves a run session by its ID or returns the first active session.
+     * 
+     * @param project The IntelliJ project context
+     * @param sessionId Optional session ID to search for
+     * @return The matching ProcessHandler if found, null otherwise
+     */
+    private fun resolveRunSession(project: Project, sessionId: String?): ProcessHandler? {
+        val executionManager = ExecutionManager.getInstance(project)
+        val runningProcesses: Array<ProcessHandler> = executionManager.getRunningProcesses()
+
+        if (sessionId == null) {
+            return runningProcesses.firstOrNull { !it.isProcessTerminated }
+        }
+
+        return runningProcesses.find { processHandler ->
+            val processId = getProcessId(processHandler)
+            processHandler.hashCode().toString() == sessionId || processId?.toString() == sessionId
+        }
+    }
+
+    /**
+     * Retrieves the process ID from a ProcessHandler using reflection.
+     * 
+     * @param processHandler The process handler to extract the ID from
+     * @return The process ID if available, null otherwise
+     */
+    private fun getProcessId(processHandler: ProcessHandler): Long? {
+        return try {
+            val process = processHandler.javaClass.getMethod("getProcess").invoke(processHandler)
+            if (process is Process) {
+                process.pid()
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/ToolRegistryTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/ToolRegistryTest.kt
@@ -154,18 +154,19 @@ class ToolRegistryTest {
     }
 
     @Test
-    fun `registerBuiltInTools registers exactly 22 tools`() {
+    fun `registerBuiltInTools registers exactly 24 tools`() {
         registry.registerBuiltInTools()
 
-        assertEquals(22, registry.getToolCount())
+        assertEquals(24, registry.getToolCount())
     }
 
     @Test
     fun `registerBuiltInTools registers all tool categories`() {
         registry.registerBuiltInTools()
 
-        // Run Configuration Tools (2)
+        // Run Configuration Tools (3)
         assertNotNull(registry.getTool("list_run_configurations"))
+        assertNotNull(registry.getTool("list_run_sessions"))
         assertNotNull(registry.getTool("execute_run_configuration"))
 
         // Debug Session Tools (4)


### PR DESCRIPTION
Currently ai coding agents use terminal to start\stop applications, and when need to stop app it sometimes kill wrong process or wait for long time, forgot to sop previouse etc. This new tools for run configuration will help to avoid usage of terminals for ai agents, just use current workflow:
intellij-debugger mcp 
- start_debug_session run mode
- list_run_sessions
- stop_run_session

Next steps would be to get run logs and mostly 90% of terminal usage for coding agent will be covered for application development.

Tested with Intellij works ok for me.