### PR TITLE
Fix Plugin Verifier problems blocking Marketplace validation (5.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Cleared the JetBrains Plugin Verifier problems that blocked Marketplace validation of 5.0.0:
+  - **Internal API**: the version reported to MCP clients was read via `PluginManagerCore.getPlugin` (an internal API). It is now generated into a bundled resource from `pluginVersion` at build time and read via the classloader — same no-drift guarantee, no internal API.
+  - **Override-only violations**: the tool-window buttons invoked `AnAction.actionPerformed` directly (marked `@ApiStatus.OverrideOnly`). They now dispatch through `ActionUtil.invokeAction`, which also removes the deprecated `AnActionEvent.createFromAnAction`.
+  - **Scheduled-for-removal APIs**: `XBreakpointManager.findBreakpointAtLine` replaced with `findBreakpointsAtLine`; `ProcessAdapter` replaced with `ProcessListener`; the deprecated `FileSaverDescriptor` constructor replaced with the `withExtensionFilter` builder.
+
 ## [5.0.0] - 2026-08-03
 
 ### Breaking

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,27 @@ kotlin {
     jvmToolchain(21)
 }
 
+// The version reported to MCP clients (McpConstants.SERVER_VERSION) is generated into a bundled
+// resource at build time and read back via the classloader — NOT from the plugin descriptor at
+// runtime. Reading the descriptor would mean PluginManagerCore.getPlugin(), which the JetBrains
+// Plugin Verifier flags as internal-API usage. This keeps the version in lockstep with
+// `pluginVersion` with no manual step and no internal API.
+val generateServerVersionResource by tasks.registering {
+    val pluginVersion = providers.gradleProperty("pluginVersion")
+    val outputDir = layout.buildDirectory.dir("generated/server-version")
+    inputs.property("pluginVersion", pluginVersion)
+    outputs.dir(outputDir)
+    doLast {
+        outputDir.get().file("META-INF/mcp-server-version.txt").asFile.apply {
+            parentFile.mkdirs()
+            writeText(pluginVersion.get())
+        }
+    }
+}
+sourceSets.main {
+    resources.srcDir(generateServerVersionResource)
+}
+
 // Configure project's dependencies
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsdebuggermcpplugin
 pluginName = Debugger MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-debugger-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.0.0
+pluginVersion = 5.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # 252 (2025.2) is the floor because the MCP Kotlin SDK cannot link below it:

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/McpConstants.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/McpConstants.kt
@@ -1,8 +1,6 @@
 package com.github.hechtcarmel.jetbrainsdebuggermcpplugin
 
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.util.IdeProductInfo
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.util.messages.Topic
 
 object McpConstants {
@@ -39,24 +37,24 @@ object McpConstants {
     @JvmStatic
     fun getServerName(): String = IdeProductInfo.getServerName()
 
-    /**
-     * Fallback for [SERVER_VERSION] used when the plugin descriptor is not loaded (plain unit
-     * tests). Must match `pluginVersion` in gradle.properties — `McpConstantsTest` pins that.
-     */
-    const val FALLBACK_SERVER_VERSION = "5.0.0"
+    /** Last-resort value if the generated version resource is somehow absent. */
+    private const val FALLBACK_SERVER_VERSION = "0.0.0"
 
     /**
      * The version reported to MCP clients during `initialize`.
      *
-     * Read from the installed plugin descriptor at runtime, so it cannot drift from the version
-     * the plugin actually ships — the previous hardcoded constant drifted twice, once for four
-     * consecutive releases. The fallback only applies where the plugin is not loaded as a plugin
-     * (unit tests).
+     * Read from a resource generated at build time from `pluginVersion` (see
+     * `generateServerVersionResource` in build.gradle.kts), so it stays in lockstep with the
+     * shipped version with no manual step. It is deliberately NOT read from the plugin descriptor
+     * at runtime: that needs `PluginManagerCore.getPlugin`, an internal API the Plugin Verifier
+     * rejects. The previous hardcoded constant drifted twice, once for four consecutive releases.
      */
     @JvmStatic
     val SERVER_VERSION: String by lazy {
-        runCatching { PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version }
-            .getOrNull() ?: FALLBACK_SERVER_VERSION
+        McpConstants::class.java.getResourceAsStream("/META-INF/mcp-server-version.txt")
+            ?.bufferedReader()?.use { it.readText().trim() }
+            ?.takeIf { it.isNotEmpty() }
+            ?: FALLBACK_SERVER_VERSION
     }
     const val SERVER_DESCRIPTION = """Debug applications running in JetBrains IDEs (IntelliJ, PyCharm, WebStorm, etc.) through programmatic control.
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/actions/CopyClientConfigAction.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/actions/CopyClientConfigAction.kt
@@ -6,7 +6,7 @@ import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.util.ClientConfigGenera
 import com.github.hechtcarmel.jetbrainsdebuggermcpplugin.util.ClientConfigGenerator.ClientType
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.icons.AllIcons
 import com.intellij.notification.NotificationGroupManager
@@ -211,7 +211,7 @@ class CopyClientConfigAction : AnAction() {
                 val handler = OSProcessHandler(commandLine)
                 val output = StringBuilder()
 
-                handler.addProcessListener(object : ProcessAdapter() {
+                handler.addProcessListener(object : ProcessListener {
                     override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
                         output.append(event.text)
                     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/actions/ExportHistoryAction.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/actions/ExportHistoryAction.kt
@@ -20,11 +20,10 @@ class ExportHistoryAction : AnAction(
         val project = e.project ?: return
         val historyService = CommandHistoryService.getInstance(project)
 
-        val descriptor = FileSaverDescriptor(
-            "Export Command History",
-            "Save command history to file",
-            "json", "csv"
-        )
+        // withExtensionFilter returns the parent FileChooserDescriptor type, so mutate in an
+        // apply block and keep the FileSaverDescriptor-typed reference the save dialog needs.
+        val descriptor = FileSaverDescriptor("Export Command History", "Save command history to file")
+            .apply { withExtensionFilter("Command history", "json", "csv") }
 
         val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val wrapper = dialog.save(null as VirtualFile?, "debugger-mcp-history")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/breakpoint/SetBreakpointTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/breakpoint/SetBreakpointTool.kt
@@ -242,7 +242,7 @@ class SetBreakpointTool : AbstractMcpTool() {
         temporary: Boolean
     ): XLineBreakpoint<*> {
         val lineType = type as XLineBreakpointType<XBreakpointProperties<*>>
-        return breakpointManager.findBreakpointAtLine(lineType, virtualFile, lineIndex)
+        return breakpointManager.findBreakpointsAtLine(lineType, virtualFile, lineIndex).firstOrNull()
             ?: breakpointManager.addLineBreakpoint(
                 lineType,
                 virtualFile.url,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/util/FrameVariablesCollector.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/tools/util/FrameVariablesCollector.kt
@@ -108,6 +108,8 @@ object FrameVariablesCollector {
                         link: XDebuggerTreeNodeHyperlink?
                     ) {}
 
+                    // Still an abstract member of XCompositeNode even though deprecated, so it must
+                    // be implemented; the real behaviour lives in the two-arg overload below.
                     @Deprecated("Deprecated in Java")
                     override fun tooManyChildren(remaining: Int) {}
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/ui/McpToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/ui/McpToolWindowFactory.kt
@@ -8,8 +8,8 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -21,6 +21,7 @@ import com.intellij.ui.components.JBPanel
 import com.intellij.ui.content.ContentFactory
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.Component
 import java.awt.Cursor
 import java.awt.FlowLayout
 import java.awt.Font
@@ -77,21 +78,7 @@ class McpToolWindowFactory : ToolWindowFactory, DumbAware {
             icon = McpIcons.ToolWindow
             toolTipText = "Copy MCP client configuration to clipboard"
             isFocusable = false
-            addActionListener {
-                val dataContext = com.intellij.openapi.actionSystem.DataContext { dataId ->
-                    when (dataId) {
-                        com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT.name -> project
-                        else -> null
-                    }
-                }
-                val event = AnActionEvent.createFromAnAction(
-                    installAction,
-                    null,
-                    ActionPlaces.TOOLWINDOW_CONTENT,
-                    dataContext
-                )
-                installAction.actionPerformed(event)
-            }
+            addActionListener { e -> fireToolbarAction(installAction, e.source as Component) }
         }
 
         val skillAction = action(INSTALL_SKILL_ACTION_ID)
@@ -99,21 +86,7 @@ class McpToolWindowFactory : ToolWindowFactory, DumbAware {
             icon = AllIcons.Actions.Download
             toolTipText = "Install or export the companion skill for AI coding agents"
             isFocusable = false
-            addActionListener {
-                val dataContext = com.intellij.openapi.actionSystem.DataContext { dataId ->
-                    when (dataId) {
-                        com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT.name -> project
-                        else -> null
-                    }
-                }
-                val event = AnActionEvent.createFromAnAction(
-                    skillAction,
-                    null,
-                    ActionPlaces.TOOLWINDOW_CONTENT,
-                    dataContext
-                )
-                skillAction.actionPerformed(event)
-            }
+            addActionListener { e -> fireToolbarAction(skillAction, e.source as Component) }
         }
 
         // Right panel with external links + install button
@@ -176,6 +149,18 @@ class McpToolWindowFactory : ToolWindowFactory, DumbAware {
     }
 
     override fun shouldBeAvailable(project: Project): Boolean = true
+
+    /**
+     * Fires a registered action from a plain Swing button.
+     *
+     * `AnAction.actionPerformed` is `@ApiStatus.OverrideOnly` — it must not be invoked directly.
+     * `ActionUtil.invokeAction` is the sanctioned entry point: it builds the data context from the
+     * source component (so the action still sees the project) and runs the action through the
+     * platform's own dispatch. This also avoids the deprecated `AnActionEvent.createFromAnAction`.
+     */
+    private fun fireToolbarAction(action: AnAction, source: Component) {
+        ActionUtil.invokeAction(action, source, ActionPlaces.TOOLWINDOW_CONTENT, null, null)
+    }
 
     /**
      * Creates a settings panel with an icon and descriptive text.

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/McpConstantsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsdebuggermcpplugin/McpConstantsTest.kt
@@ -48,42 +48,30 @@ class McpConstantsTest {
     fun `server version follows semver pattern`() {
         val semverRegex = Regex("""\d+\.\d+\.\d+(-[\w.]+)?""")
         assertTrue(semverRegex.matches(McpConstants.SERVER_VERSION))
-        assertTrue(semverRegex.matches(McpConstants.FALLBACK_SERVER_VERSION))
     }
 
     /**
      * `SERVER_VERSION` is what the plugin reports to MCP clients in `initialize`, so it has to be
-     * the version the plugin actually ships. It is now read from the installed plugin descriptor
-     * at runtime, which cannot drift; but its unit-test fallback constant still can.
+     * the version the plugin actually ships. It is generated into a bundled resource from
+     * `pluginVersion` at build time and read back via the classloader — so it cannot drift, and
+     * needs no internal plugin-descriptor API (which the Plugin Verifier rejects).
      *
-     * History: the old hardcoded constant had drifted to `4.0.0` while the plugin shipped 4.3.1 —
-     * and the then-current version of this test asserted the literal `"4.0.0"`, which meant the
-     * suite actively prevented the constant from being corrected. Comparing against
-     * `gradle.properties` instead makes the fallback impossible to leave behind.
+     * History: an earlier hardcoded constant drifted to `4.0.0` while the plugin shipped 4.3.1.
+     * `processResources` runs the generator before tests, so this reads the real generated value.
      */
     @Test
-    fun `fallback server version matches the shipped plugin version`() {
+    fun `server version matches the shipped plugin version`() {
         val pluginVersion = java.io.File("gradle.properties").readLines()
             .firstOrNull { it.trimStart().startsWith("pluginVersion") }
             ?.substringAfter('=')?.trim()
 
         assertNotNull("Could not read pluginVersion from gradle.properties", pluginVersion)
         assertEquals(
-            "McpConstants.FALLBACK_SERVER_VERSION stands in for the plugin-descriptor version in " +
-                "unit tests and must match gradle.properties' pluginVersion.",
+            "McpConstants.SERVER_VERSION is generated from gradle.properties' pluginVersion and " +
+                "reported to every MCP client during initialize; the two must agree.",
             pluginVersion,
-            McpConstants.FALLBACK_SERVER_VERSION
+            McpConstants.SERVER_VERSION
         )
-    }
-
-    /**
-     * Whether the descriptor is loaded (platform tests) or not (plain unit tests), the reported
-     * version must resolve to the shipped plugin version — the descriptor's version and the
-     * fallback are both pinned to gradle.properties, so the two paths must agree.
-     */
-    @Test
-    fun `server version resolves to a non-blank version`() {
-        assertTrue(McpConstants.SERVER_VERSION.isNotBlank())
     }
 
     @Test


### PR DESCRIPTION
5.0.0 passed the IDE-run check but the JetBrains **Plugin Verifier** reported **Problems** on newer IDEs (2026.1/2026.2), which blocks Marketplace validation. This clears them.

## Root causes → fixes

| Verifier problem | Cause | Fix |
|---|---|---|
| **1 internal API usage** | `SERVER_VERSION` read the plugin version via `PluginManagerCore.getPlugin` (internal) | Generate the version into a bundled resource from `pluginVersion` at build time (`generateServerVersionResource`), read via the classloader — same no-drift guarantee, zero internal API |
| **2 override-only violations** | Tool-window buttons called `AnAction.actionPerformed` directly (`@ApiStatus.OverrideOnly`) | Dispatch through `ActionUtil.invokeAction` (also drops the deprecated `AnActionEvent.createFromAnAction`) |
| **3 scheduled-for-removal** | `findBreakpointAtLine`, `ProcessAdapter`, deprecated `FileSaverDescriptor` ctor | `findBreakpointsAtLine`, `ProcessListener`, `withExtensionFilter` builder |

## Result

Local Plugin Verifier verdict:

- **Before:** `Problems` — 1 internal API, 2 override-only violations, 3 scheduled-for-removal, 4 deprecated
- **After:** `Compatible. 2 usages of deprecated API`

Both residuals are yellow warnings: `ActionUtil.invokeAction` (a minor UI-action deprecation whose replacement needs a hand-built `AnActionEvent`) and `XCompositeNode.tooManyChildren(int)`, which is a **required abstract** member the interface still declares — unavoidable.

Bumped to **5.0.1** to republish, since 5.0.0 is already on the Marketplace.

**Tests:** 413 green; `verifyPlugin` verdict `Compatible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)